### PR TITLE
fix(security): activate CODEOWNERS + docs-vs-enforcement truth pass

### DIFF
--- a/.claude/commands/init-template.md
+++ b/.claude/commands/init-template.md
@@ -35,7 +35,7 @@ Ask for:
 | `.github/copilot-instructions.md` | Mirror changes |
 | `.github/workflows/ci.yml` | Uncomment relevant language section |
 | `.github/dependabot.yml` | Uncomment relevant ecosystem |
-| `.github/CODEOWNERS` | Fill in owner username |
+| `.github/CODEOWNERS` | Replace every `@vbonk` with the user's GitHub handle (rules ship ACTIVE — do not comment them out) |
 | `CODE_OF_CONDUCT.md` | Fill in enforcement email |
 | `SECURITY.md` | Add security contact email |
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,50 +10,53 @@
 # .cursorrules must be reviewed by YOU — preventing prompt injection
 # attacks where someone sneaks malicious instructions into your AI config.
 #
-# Setup: Uncomment the lines below and replace @your-username with
-# your GitHub handle (e.g., @octocat). Requires branch protection with
-# "Require review from Code Owners" enabled (see docs/BRANCH-PROTECTION.md).
+# Setup: The security-critical rules below ship ACTIVE with the template
+# maintainer's handle; /project:init-template replaces @vbonk with your
+# GitHub handle. Review-request behavior works immediately; to make owner
+# review REQUIRED (blocking), enable "Require review from Code Owners" in
+# branch protection (see docs/BRANCH-PROTECTION.md).
 #
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 # Format: each line is — file-pattern   @owner(s)
 #
-# === Uncomment and replace @your-username with your GitHub username ===
+# === Optional broad ownership (uncomment if you want everything owned) ===
 #
 # Global default — all files
-# *                              @your-username
-#
-# CI/CD — workflow and action changes
-# .github/                       @your-username
+# *                              @vbonk
 #
 # Documentation
-# *.md                           @your-username
-# docs/                          @your-username
-#
+# *.md                           @vbonk
+# docs/                          @vbonk
+
+# === ACTIVE RULES — replaced with your username by /project:init-template ===
+
 # Security-sensitive files
-# .github/workflows/             @your-username
-# SECURITY.md                    @your-username
-#
+.github/workflows/             @vbonk
+SECURITY.md                    @vbonk
+
 # AI agent configuration — PROMPT INJECTION DEFENSE
 # Why: "Prompt injection" is when someone hides malicious instructions in a
 # PR, issue, or code comment to trick an AI agent into harmful actions —
 # like revealing API keys or disabling security settings. Requiring owner
 # review on these files means no one can modify your AI's instructions
 # without your explicit approval.
-# CLAUDE.md                      @your-username
-# AGENTS.md                      @your-username
-# GEMINI.md                      @your-username
-# .cursorrules                   @your-username
-# .windsurfrules                 @your-username
-# .github/copilot-instructions.md @your-username
-# .claude/skills/                 @your-username
-# .claude/agents/                 @your-username
-#
+CLAUDE.md                      @vbonk
+AGENTS.md                      @vbonk
+GEMINI.md                      @vbonk
+.cursorrules                   @vbonk
+.windsurfrules                 @vbonk
+.github/copilot-instructions.md @vbonk
+.claude/skills/                 @vbonk
+.claude/agents/                 @vbonk
+.claude/hooks/                  @vbonk
+.claude/commands/               @vbonk
+
 # Security hardening files — SECURITY DOWNGRADE DEFENSE
 # Why: These files control your repo's security protections (hooks, scanning,
 # secret detection). A PR that weakens these files should always require your
 # review — whether the change comes from a collaborator or an AI agent.
-# scripts/secure-repo.sh           @your-username
-# templates/hooks/                 @your-username
-# .github/workflows/secret-scan-pr.yml @your-username
-# .gitattributes                   @your-username
+scripts/secure-repo.sh           @vbonk
+templates/hooks/                 @vbonk
+.github/workflows/secret-scan-pr.yml @vbonk
+.gitattributes                   @vbonk

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Yes! See Workflow F. Add your AI configuration files (CLAUDE.md, etc.) and exclu
 
 This template includes prompt injection defenses — a first for GitHub templates:
 
-- **CODEOWNERS** protects AI config files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) — changes require owner review
+- **CODEOWNERS** ships with active rules on AI config files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) — owner review is auto-requested on changes; enable "Require review from Code Owners" in branch protection to make it blocking
 - **PR body scanner** (opt-in workflow) detects common injection patterns in issue/PR text
 - **Hook templates** validate inputs before AI agents process them
 - **Documentation** in [docs/AI-SECURITY.md](docs/AI-SECURITY.md) covers attack vectors and best practices

--- a/docs/AI-SECURITY.md
+++ b/docs/AI-SECURITY.md
@@ -7,7 +7,7 @@ This is not a theoretical problem. AI-assisted commits leak secrets at twice the
 > [!IMPORTANT]
 > **Why this matters to you:** If you're building with Claude Code, Cursor, Copilot, or any AI coding tool, the code it writes for you is statistically likely to contain security issues. You don't need to become a security expert — but you do need guardrails that catch the mistakes before they reach your repo. That's what this page sets up.
 
-> **Threat Model at a Glance** -- This repository defends against prompt injection attacks through 6 layers of defense-in-depth: CODEOWNERS review gates, branch protection, CI validation, hook-based scanning, agent-level instructions, and secret detection. All AI config files are protected by CODEOWNERS. All changes require PR review. Agents cannot self-approve.
+> **Threat Model at a Glance** -- This repository defends against prompt injection attacks through 6 layers of defense-in-depth: CODEOWNERS review gates, branch protection, CI validation, hook-based scanning, agent-level instructions, and secret detection. AI config files carry active CODEOWNERS rules (review is *requested* automatically; to make it *blocking*, enable "Require review from Code Owners" — see docs/BRANCH-PROTECTION.md). On a hardened repo, all changes to `main` must arrive by PR with passing status checks — direct pushes are rejected, including from agents.
 
 ---
 
@@ -80,13 +80,14 @@ These files control AI agent behavior and are protected by CODEOWNERS:
 | `.github/copilot-instructions.md` | GitHub Copilot | Copilot custom instructions |
 | `.claude/hooks/` | Claude Code hooks | Pre/post tool-use automation |
 | `.claude/commands/` | Claude Code commands | Slash command definitions |
-| `.claude/settings.json` | Claude Code settings | Agent behavior configuration |
+| `.claude/skills/` | Claude Code skills | Executable skill instructions |
+| `.claude/agents/` | Claude Code agents | Sub-agent definitions |
 
 ## Best Practices
 
 ### For Maintainers
 
-1. **Enable CODEOWNERS** -- Uncomment the AI config protection lines in `.github/CODEOWNERS` and replace `@your-username` with your GitHub handle.
+1. **Verify CODEOWNERS is yours** -- The AI config protection rules ship active; `/project:init-template` replaces the maintainer's handle with yours. Confirm with `grep -E '^[^#]' .github/CODEOWNERS` that the active rules name YOUR handle.
 
 2. **Enable branch protection** -- See [BRANCH-PROTECTION.md](BRANCH-PROTECTION.md) for the recommended settings and a `gh api` script.
 

--- a/docs/BRANCH-PROTECTION.md
+++ b/docs/BRANCH-PROTECTION.md
@@ -5,16 +5,16 @@
 
 A single `git push --force` to an unprotected `main` branch can erase your entire commit history. It has happened to solo developers — one bad command and weeks of work vanish with no way to recover it. Branch protection is a seatbelt, not enterprise governance. It takes 30 seconds to enable and costs nothing. You hope you never need it, but when you do, it saves everything.
 
-> **Protection at a Glance** -- Require PR reviews, CI checks, signed commits, and linear history on `main`. AI agents must use PRs and cannot self-approve. CODEOWNERS gates AI config file changes behind human review.
+> **Protection at a Glance** -- What `scripts/secure-repo.sh` enforces out of the box, and what you can add on top. Be precise about which is which: a protection listed as "opt-in" protects nothing until you enable it.
 >
-> | Protection | Status | Notes |
-> |------------|--------|-------|
-> | PR required before merge | Required | At least 1 approval |
-> | CODEOWNERS review | Required | For AI config files |
-> | Status checks (CI, CodeQL) | Required | Must pass before merge |
-> | Signed commits | Recommended | Proves authorship |
-> | Linear history | Recommended | Enforces rebase/squash |
-> | Force push / deletion | Blocked | On `main` and `v*` tags |
+> | Protection | Out of the box (secure-repo.sh) | Opt-in upgrade |
+> |------------|--------------------------------|----------------|
+> | Force push / deletion blocked | ✅ `main` and `v*` tags (rulesets) | — |
+> | Status checks required before merge | ✅ once your CI jobs exist (rejects direct pushes too) | Add more required contexts |
+> | PR required with approvals | — | 1+ approvals; needed for teams |
+> | CODEOWNERS review *blocking* | Review auto-requested (rules ship active) | "Require review from Code Owners" makes it blocking |
+> | Signed commits | — | Proves authorship |
+> | Linear history | — | Enforces rebase/squash |
 
 ---
 
@@ -37,32 +37,69 @@ Apply to the `main` branch (or your default branch):
 - [x] **Do not allow force pushes**
 - [x] **Do not allow deletions**
 
-## Apply via GitHub CLI
+## Apply via GitHub CLI (rulesets — recommended)
+
+Rulesets are GitHub's current mechanism (classic branch protection still works
+but new capabilities only land in rulesets). This creates the same protection
+this template's maintainer repo runs:
 
 ```bash
-# Requires gh CLI authenticated with admin access
-# Adjust owner/repo and required checks for your project
+# Requires gh CLI authenticated with admin access.
+# Adjust the required check contexts to YOUR CI job names.
 
 OWNER="your-username"
 REPO="your-repo"
 
-gh api \
-  --method PUT \
-  "repos/$OWNER/$REPO/branches/main/protection" \
-  -f 'required_status_checks[strict]=true' \
-  -f 'required_status_checks[contexts][]=ci' \
-  -f 'required_status_checks[contexts][]=codeql' \
-  -f 'required_pull_request_reviews[dismiss_stale_reviews]=true' \
-  -f 'required_pull_request_reviews[require_code_owner_reviews]=true' \
-  -F 'required_pull_request_reviews[required_approving_review_count]=1' \
-  -f 'enforce_admins=true' \
-  -f 'restrictions=null' \
-  -f 'required_linear_history=true' \
-  -f 'allow_force_pushes=false' \
-  -f 'allow_deletions=false'
-
-echo "Branch protection applied to main"
+gh api --method POST "repos/$OWNER/$REPO/rulesets" --input - <<'EOF'
+{
+  "name": "Protect Main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_status_checks",
+      "parameters": { "strict_required_status_checks_policy": false,
+        "required_status_checks": [ { "context": "build" }, { "context": "validate" } ] } }
+  ],
+  "bypass_actors": [ { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "pull_request" } ]
+}
+EOF
+echo "Ruleset applied to default branch"
 ```
+
+> [!TIP]
+> The `bypass_actors` entry lets repo admins bypass **only via pull request** —
+> never use `"bypass_mode": "always"`, which lets an admin (or an agent with
+> admin credentials) sidestep every rule. Scope conditions to
+> `~DEFAULT_BRANCH`: a ruleset matching `~ALL` branches breaks Dependabot,
+> which force-pushes to its own branches when rebasing.
+
+<details>
+<summary>Classic branch-protection API (legacy alternative)</summary>
+
+```bash
+# NOTE: the payload must be sent as a JSON body. gh's -f flag sends strings
+# ("null" is NOT JSON null), which this endpoint rejects with a 422.
+gh api --method PUT "repos/$OWNER/$REPO/branches/main/protection" --input - <<'EOF'
+{
+  "required_status_checks": { "strict": true, "contexts": ["build", "validate"] },
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "enforce_admins": true,
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+</details>
 
 ## Protected Tags
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -523,10 +523,17 @@ run_layer_4() {
   assert_contains .github/workflows/secret-scan-pr.yml "pull-requests: write" "secret-scan-pr: pull-requests write permission"
   assert_contains .github/workflows/secret-scan-pr.yml "KNOWN LIMITATION" "secret-scan-pr: fork limitation documented"
 
-  # 4.11 CODEOWNERS covers security files
-  assert_contains .github/CODEOWNERS "secure-repo.sh" "CODEOWNERS: secure-repo.sh listed"
-  assert_contains .github/CODEOWNERS "templates/hooks" "CODEOWNERS: templates/hooks listed"
-  assert_contains .github/CODEOWNERS ".gitattributes" "CODEOWNERS: .gitattributes listed"
+  # 4.11 CODEOWNERS covers security files with ACTIVE (uncommented) rules.
+  # Design check, not existence check: a commented-out rule protects nothing,
+  # so we only accept lines that are not comments.
+  local co_pattern
+  for co_pattern in "secure-repo.sh" "templates/hooks" ".gitattributes"; do
+    if grep -E '^[^#[:space:]]' .github/CODEOWNERS 2>/dev/null | grep -q "$co_pattern"; then
+      pass "CODEOWNERS: $co_pattern actively owned"
+    else
+      fail "CODEOWNERS: $co_pattern rule missing or commented out (inert)"
+    fi
+  done
 
   # 4.12 .gitignore blocks .env
   echo "SECRET=test" > .env.test-verify


### PR DESCRIPTION
Closes the gap between advertised and actual protection: CODEOWNERS rules ship active, the self-test verifies design (active rules) not existence (string present), and AI-SECURITY/BRANCH-PROTECTION/README claim exactly what is enforced. Part of the trust-layer hardening wave.

Tony