### PR TITLE
fix(security): secret scanner redaction + pattern upgrade

### DIFF
--- a/.github/workflows/secret-scan-pr.yml
+++ b/.github/workflows/secret-scan-pr.yml
@@ -48,23 +48,43 @@ jobs:
             exit 0
           fi
 
-          # Secret patterns (POSIX-compatible — uses [[:space:]] not \s)
-          PATTERNS='(AKIA[A-Z0-9]{16}|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|ghs_[a-zA-Z0-9]{36}|sk-ant-[a-zA-Z0-9]+|sk-proj-[a-zA-Z0-9]+|sk-live-[a-zA-Z0-9]+|-----BEGIN[[:space:]]+(RSA[[:space:]]+|EC[[:space:]]+|OPENSSH[[:space:]]+)?PRIVATE[[:space:]]+KEY)'
+          # Secret patterns (POSIX-compatible — uses [[:space:]] not \s).
+          # All patterns here are high-precision provider tokens, so .md/.txt
+          # files are scanned too (prose can leak real keys; these prefixes
+          # don't false-positive on normal text).
+          # Format: "Label|regex" — one per line.
+          PATTERN_LIST='AWS access key|AKIA[A-Z0-9]{16}
+          GitHub classic token|gh[pos]_[a-zA-Z0-9]{36}
+          GitHub fine-grained PAT|github_pat_[A-Za-z0-9_]{22,}
+          GitHub user/refresh token|gh[ur]_[A-Za-z0-9]{36,}
+          Anthropic API key|sk-ant-[a-zA-Z0-9-]+
+          OpenAI project key|sk-proj-[a-zA-Z0-9]+
+          Stripe live key|sk_live_[0-9a-zA-Z]{24,}
+          Slack token|xox[baprs]-[A-Za-z0-9-]{10,}
+          Google API key|AIza[0-9A-Za-z_-]{35}
+          npm token|npm_[A-Za-z0-9]{36}
+          JWT|eyJ[A-Za-z0-9_-]{20,}\.eyJ
+          Private key block|-----BEGIN[[:space:]]+(RSA[[:space:]]+|EC[[:space:]]+|OPENSSH[[:space:]]+)?PRIVATE[[:space:]]+KEY'
 
+          # SECURITY: never place matched content in findings — a captured
+          # secret pasted into a PR comment is a secondary leak (comments are
+          # durable and bot-authored). Report file:line + pattern label ONLY.
+          # Displayed filenames are sanitized (they are PR-author-controlled).
           FINDINGS=""
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             [ ! -f "$file" ] && continue
+            SAFE_NAME=$(printf '%s' "$file" | tr -cd 'A-Za-z0-9._/-')
 
-            # Skip markdown and documentation
-            case "$file" in
-              *.md|*.txt|*.rst) continue ;;
-            esac
-
-            MATCHES=$(grep -nE "$PATTERNS" "$file" 2>/dev/null || true)
-            if [ -n "$MATCHES" ]; then
-              FINDINGS="${FINDINGS}\n**${file}**:\n\`\`\`\n${MATCHES}\n\`\`\`\n"
-            fi
+            while IFS='|' read -r label regex; do
+              label=$(printf '%s' "$label" | sed 's/^[[:space:]]*//')
+              [ -z "$regex" ] && continue
+              # -e guards against regexes that start with '-' (private-key pattern)
+              LINES=$(grep -nE -e "$regex" "$file" 2>/dev/null | cut -d: -f1 | tr '\n' ',' | sed 's/,$//')
+              if [ -n "$LINES" ]; then
+                FINDINGS="${FINDINGS}- \`${SAFE_NAME}\` line(s) ${LINES} — ${label}\n"
+              fi
+            done <<< "$PATTERN_LIST"
           done <<< "$CHANGED"
 
           if [ -n "$FINDINGS" ]; then
@@ -76,8 +96,12 @@ jobs:
             echo "No secret patterns found."
           fi
 
+      # continue-on-error: fork PRs run with a read-only token and this step
+      # 403s — that is the documented limitation, not a scan failure, so it
+      # must not paint a red X on exactly the PRs that most need the scan.
       - name: Post warning comment
         if: steps.scan.outputs.found == 'true'
+        continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -86,7 +110,7 @@ jobs:
             const body = [
               '## :warning: Potential Secrets Detected',
               '',
-              'The following files contain patterns that may be secrets or credentials:',
+              'These locations matched secret patterns (matched content is deliberately NOT shown — check the lines locally):',
               '',
               findings,
               '',


### PR DESCRIPTION
Codex finding N1 + register M2 (workflow half): the scanner republished suspected secrets verbatim into PR comments. Now reports `file:line — pattern name` only, with sanitized filenames, expanded 2026 token patterns (incl. the sk_live_ hyphen bug fix), .md scanning for high-precision patterns, and continue-on-error on the fork-PR comment step.

Tony