### PR TITLE
fix(security): hook single-quote gap + 2026 secret patterns

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -501,11 +501,20 @@ run_layer_4() {
   # 4.6 Hook allows clean files
   test_hook_allows "clean code" "const greeting = 'hello world';" "test-sec-46.js"
 
-  # 4.7 Hook skips .md files
-  test_hook_allows ".md with patterns" "Example: sk-ant-example123456 is a pattern" "test-sec-47.md"
+  # 4.7 Precise provider tokens BLOCK even in .md — a real key pasted into
+  # a README is just as leaked. Prefix-only prose stays allowed.
+  test_hook_blocks ".md with realistic token" "Example: sk-ant-""api03realistic456 leaked here" "test-sec-47.md"
+  test_hook_allows ".md prefix-only prose" "The hook catches sk-ant-* and AKIA prefixes" "test-sec-47b.md"
 
   # 4.8 Hook skips .template files
   test_hook_allows ".template with patterns" "AKIA pattern check" "test-sec-48.template"
+
+  # 4.13 2026 token formats + single-quoted generic values (BSD-grep regression:
+  # \x27 escapes silently broke single-quote detection on macOS)
+  test_hook_blocks "fine-grained PAT" "pat = 'github_pat_""11ABCDEF0123456789_abcdefghij'" "test-sec-49.py"
+  test_hook_blocks "Slack token" "SLACK='xoxb-""123456789012-abcdef'" "test-sec-50.py"
+  test_hook_blocks "Stripe live key" "stripe = 'sk_live_""ABCDEFGHIJKLMNOPQRSTUVWX99'" "test-sec-51.js"
+  test_hook_blocks "single-quoted password" "password = 'hunter2hunter2'" "test-sec-52.py"
 
   # 4.9 POSIX patterns — no \s in hooks (search for literal backslash-s)
   if grep -q '\\s' templates/hooks/pre-commit-secrets.sh.template 2>/dev/null; then

--- a/templates/hooks/pre-commit-secrets.sh.template
+++ b/templates/hooks/pre-commit-secrets.sh.template
@@ -74,36 +74,61 @@ if [[ -n "$STAGED_FILES" && ${#TOKENS[@]} -gt 0 ]]; then
 fi
 
 # --- Check 2: Secret patterns (regex) ---
-# Uses [[:space:]] for POSIX compatibility (works on macOS BSD grep and GNU grep)
-SECRET_PATTERNS=(
+# Uses [[:space:]] for POSIX compatibility (works on macOS BSD grep and GNU grep).
+# NOTE: quote characters appear as ['\''"] built via shell quoting — do NOT
+# use \x27 escapes: BSD grep does not understand them, which silently broke
+# single-quoted secret detection on macOS for months.
+#
+# Two groups with different file scopes:
+# PRECISE — provider token formats. Near-zero false positives, so these scan
+# ALL staged files including docs (.md/.txt): a real key pasted into a README
+# is just as leaked.
+SECRET_PATTERNS_PRECISE=(
   'PRIVATE.KEY'
   'BEGIN RSA'
   'BEGIN OPENSSH'
   'BEGIN EC PRIVATE'
   'BEGIN PGP PRIVATE'
-  'password[[:space:]]*[:=][[:space:]]*["\x27][^"\x27]{8,}'
-  'secret[[:space:]]*[:=][[:space:]]*["\x27][^"\x27]{8,}'
-  'api[_-]?key[[:space:]]*[:=][[:space:]]*["\x27][^"\x27]{8,}'
-  'token[[:space:]]*[:=][[:space:]]*["\x27][^"\x27]{8,}'
+  'AKIA[A-Z0-9]{16}'
+  'gh[pos]_[a-zA-Z0-9]{36}'
+  'github_pat_[A-Za-z0-9_]{22,}'
+  'gh[ur]_[A-Za-z0-9]{36,}'
+  'sk-ant-[a-zA-Z0-9-]+'
+  'sk-proj-[a-zA-Z0-9]+'
+  'sk_live_[0-9a-zA-Z]{24,}'
+  'xox[baprs]-[A-Za-z0-9-]{10,}'
+  'AIza[0-9A-Za-z_-]{35}'
+  'npm_[A-Za-z0-9]{36}'
+  'eyJ[A-Za-z0-9_-]{20,}\.eyJ'
+)
+# GENERIC — password/secret/token assignments. Prose-prone, so docs are
+# skipped. Values may be double- OR single-quoted (both grep flavors).
+SECRET_PATTERNS_GENERIC=(
+  'password[[:space:]]*[:=][[:space:]]*["'\''][^"'\'']{8,}'
+  'secret[[:space:]]*[:=][[:space:]]*["'\''][^"'\'']{8,}'
+  'api[_-]?key[[:space:]]*[:=][[:space:]]*["'\''][^"'\'']{8,}'
+  'token[[:space:]]*[:=][[:space:]]*["'\''][^"'\'']{8,}'
   'aws_access_key_id[[:space:]]*='
   'aws_secret_access_key[[:space:]]*='
-  'AKIA[A-Z0-9]{16}'
-  'ghp_[a-zA-Z0-9]{36}'
-  'gho_[a-zA-Z0-9]{36}'
-  'ghs_[a-zA-Z0-9]{36}'
-  'sk-ant-[a-zA-Z0-9]+'
-  'sk-proj-[a-zA-Z0-9]+'
 )
 
-if [[ -n "$STAGED_FILES" ]]; then
-  for pattern in "${SECRET_PATTERNS[@]}"; do
+scan_patterns() {
+  # $1 = "precise" | "generic" — controls the doc-file skip
+  local group="$1"; shift
+  local pattern matches
+  for pattern in "$@"; do
     matches=$(echo "$STAGED_FILES" | while IFS= read -r f; do
       [[ -z "$f" ]] && continue
-      # Skip files that legitimately contain secret patterns (docs, templates, security tooling)
+      # Files that legitimately contain secret patterns (examples, security tooling)
       case "$f" in
-        (*.example|*.md|*.txt|*.template) continue ;;
+        (*.example|*.template) continue ;;
         (templates/hooks/*|.github/workflows/*|scripts/test-template.sh|scripts/test-e2e.sh|.gitignore|.gitattributes) continue ;;
       esac
+      if [[ "$group" == "generic" ]]; then
+        case "$f" in
+          (*.md|*.txt|*.rst) continue ;;
+        esac
+      fi
       git show ":$f" 2>/dev/null | grep -iEn -- "$pattern" | while IFS= read -r match; do
         echo "  $f:$match"
       done
@@ -118,6 +143,11 @@ if [[ -n "$STAGED_FILES" ]]; then
       BLOCKED=1
     fi
   done
+}
+
+if [[ -n "$STAGED_FILES" ]]; then
+  scan_patterns precise "${SECRET_PATTERNS_PRECISE[@]}"
+  scan_patterns generic "${SECRET_PATTERNS_GENERIC[@]}"
 fi
 
 # --- Check 3: .env files ---


### PR DESCRIPTION
Codex finding N4 + register M2 (hook half): BSD grep doesn't parse \x27, so single-quoted secrets passed the hook on macOS. Also adds current token formats, scans docs with precise patterns only, and extends the Layer-4 fixture matrix (all green in a clean clone on BSD grep).

Tony