### PR TITLE
fix(security): read-only --audit mode for secure-repo.sh

### DIFF
--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -2,15 +2,21 @@
 
 Run a comprehensive security posture check on this repository.
 
+> [!IMPORTANT]
+> This command is READ-ONLY. It reports posture and remediation commands but
+> changes nothing. Only run `bash scripts/secure-repo.sh` (no flag — the
+> hardening mode, which mutates repo settings) when the user explicitly asks
+> to apply fixes.
+
 ## Steps
 
-### 1. Run the hardening script in audit mode
+### 1. Run the audit (read-only)
 
 ```bash
-bash scripts/secure-repo.sh
+bash scripts/secure-repo.sh --audit
 ```
 
-This checks GitHub settings (Dependabot, branch protection, tag protection, Actions permissions) and local protections (pre-commit hooks, forbidden tokens, .gitattributes, commit signing). Outputs a letter grade (A+ through D).
+This reads GitHub settings (Dependabot, branch/tag rulesets, required checks, Actions permissions) and local protections (pre-commit hooks, forbidden tokens, .gitattributes, commit signing) via GET requests only, printing each gap with the exact fix command. Outputs a letter grade (A+ through D).
 
 ### 2. Review the scorecard
 
@@ -41,13 +47,13 @@ Beyond the script, manually verify:
 
 - **CodeQL configured**: Check if a language is uncommented in `.github/workflows/codeql.yml`
 
-### 4. Offer to fix
+### 4. Offer to fix — but do NOT run fixes unprompted
 
-For any issues found, offer to run the fix commands. Group them:
+Present the fix commands and ask the user which to apply. Only after explicit confirmation:
 
-**Quick fixes (safe to run now):**
-- `bash scripts/secure-repo.sh` (if not already run)
-- `bash templates/hooks/setup-hooks.sh` (if hooks missing)
+**Quick fixes (after user confirms):**
+- `bash scripts/secure-repo.sh` (hardening mode — mutates GitHub settings)
+- `bash templates/hooks/setup-hooks.sh` (if hooks missing — local only)
 
 **Manual steps (provide instructions):**
 - Commit signing setup (see `docs/BRANCH-PROTECTION.md`)

--- a/scripts/secure-repo.sh
+++ b/scripts/secure-repo.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # secure-repo.sh — Automated GitHub repository security hardening
-# Usage: ./scripts/secure-repo.sh [--repo owner/repo] [--skip-wiki] [--skip-projects]
+# Usage: ./scripts/secure-repo.sh [--audit] [--repo owner/repo] [--skip-wiki] [--skip-projects]
+#   --audit  Read-only mode: reports current security posture and the exact
+#            command each fix would run. Makes ZERO changes (GET requests only).
+#   (no flag) Applies hardening (PUT/POST/PATCH mutations).
 # If no --repo specified, auto-detects from git remote.
-# Requires: gh CLI authenticated with admin access.
+# Requires: gh CLI authenticated (admin access needed for hardening mode).
 set -euo pipefail
 
 # shellcheck source=_lib.sh
@@ -17,9 +20,11 @@ NC='\033[0m'
 REPO=""
 SKIP_WIKI=false
 SKIP_PROJECTS=false
+AUDIT=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --audit) AUDIT=true; shift ;;
     --repo) REPO="$2"; shift 2 ;;
     --skip-wiki) SKIP_WIKI=true; shift ;;
     --skip-projects) SKIP_PROJECTS=true; shift ;;
@@ -32,7 +37,11 @@ if [[ -z "$REPO" ]]; then
 fi
 
 echo "============================================"
-echo "  Repository Security Hardening"
+if $AUDIT; then
+  echo "  Repository Security Audit (read-only)"
+else
+  echo "  Repository Security Hardening"
+fi
 echo "  Repo: $REPO"
 echo "============================================"
 echo ""
@@ -60,22 +69,84 @@ run_check() {
   fi
 }
 
-# --- Dependabot Vulnerability Alerts ---
-echo "Security Features:"
-run_check "Dependabot vulnerability alerts" \
-  "gh api -X PUT repos/$REPO/vulnerability-alerts" \
-  "May require admin access or GitHub Advanced Security"
+# audit_check: READ-ONLY posture check. $2 must be a GET/read command that
+# succeeds only when the protection is configured. $3 is the remediation.
+audit_check() {
+  local name="$1" cmd="$2" fix="$3"
+  if eval "$cmd" >/dev/null 2>&1; then
+    echo -e "  ${GREEN}[PASS]${NC} $name"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${YELLOW}[WARN]${NC} $name — not configured"
+    echo "         Fix: $fix"
+    WARN=$((WARN + 1))
+  fi
+}
 
-run_check "Automated security fixes" \
-  "gh api -X PUT repos/$REPO/automated-security-fixes" \
-  "May require admin access"
-
-# --- Branch Protection ---
 DEFAULT_BRANCH=$(gh repo view "$REPO" --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
-echo ""
-echo "Branch Protection (${DEFAULT_BRANCH}):"
-run_check "Block force-push and branch deletion" \
-  "gh api -X PUT repos/$REPO/branches/$DEFAULT_BRANCH/protection --silent --input - <<'BPEOF'
+
+if $AUDIT; then
+  # ---------- READ-ONLY AUDIT (GET requests only, zero mutations) ----------
+  echo "Security Features:"
+  audit_check "Dependabot vulnerability alerts" \
+    "gh api repos/$REPO/vulnerability-alerts" \
+    "bash scripts/secure-repo.sh   (hardening mode)"
+  audit_check "Automated security fixes" \
+    "gh api repos/$REPO/automated-security-fixes --jq '.enabled' | grep -q true" \
+    "bash scripts/secure-repo.sh"
+
+  echo ""
+  echo "Branch Protection (${DEFAULT_BRANCH}):"
+  audit_check "Force-push blocked" \
+    "gh api repos/$REPO/rules/branches/$DEFAULT_BRANCH --jq '[.[].type]' | grep -q non_fast_forward" \
+    "bash scripts/secure-repo.sh, or see docs/BRANCH-PROTECTION.md for rulesets"
+  audit_check "Branch deletion blocked" \
+    "gh api repos/$REPO/rules/branches/$DEFAULT_BRANCH --jq '[.[].type]' | grep -q '\"deletion\"'" \
+    "bash scripts/secure-repo.sh"
+  audit_check "Required status checks" \
+    "gh api repos/$REPO/rules/branches/$DEFAULT_BRANCH --jq '[.[].type]' | grep -q required_status_checks" \
+    "see docs/BRANCH-PROTECTION.md (ruleset recipe with your CI job names)"
+
+  echo ""
+  echo "Tag Protection:"
+  audit_check "v* tag ruleset active" \
+    "gh api repos/$REPO/rulesets --jq '[.[] | select(.target==\"tag\" and .enforcement==\"active\")] | length' | grep -qv '^0$'" \
+    "see docs/BRANCH-PROTECTION.md §Protected Tags"
+
+  echo ""
+  echo "Repository Settings:"
+  audit_check "Delete-branch-on-merge enabled" \
+    "gh api repos/$REPO --jq '.delete_branch_on_merge' | grep -q true" \
+    "gh repo edit $REPO --delete-branch-on-merge"
+  audit_check "Wiki disabled" \
+    "gh api repos/$REPO --jq '.has_wiki' | grep -q false" \
+    "gh repo edit $REPO --enable-wiki=false   (skip if you use the wiki)"
+  audit_check "Projects disabled" \
+    "gh api repos/$REPO --jq '.has_projects' | grep -q false" \
+    "gh repo edit $REPO --enable-projects=false   (skip if you use Projects)"
+
+  echo ""
+  echo "Actions Permissions:"
+  audit_check "Default workflow permissions: read" \
+    "gh api repos/$REPO/actions/permissions/workflow --jq '.default_workflow_permissions' | grep -q read" \
+    "bash scripts/secure-repo.sh"
+else
+  # ---------- HARDENING (mutations) ----------
+  # --- Dependabot Vulnerability Alerts ---
+  echo "Security Features:"
+  run_check "Dependabot vulnerability alerts" \
+    "gh api -X PUT repos/$REPO/vulnerability-alerts" \
+    "May require admin access or GitHub Advanced Security"
+
+  run_check "Automated security fixes" \
+    "gh api -X PUT repos/$REPO/automated-security-fixes" \
+    "May require admin access"
+
+  # --- Branch Protection ---
+  echo ""
+  echo "Branch Protection (${DEFAULT_BRANCH}):"
+  run_check "Block force-push and branch deletion" \
+    "gh api -X PUT repos/$REPO/branches/$DEFAULT_BRANCH/protection --silent --input - <<'BPEOF'
 {
   \"required_status_checks\": null,
   \"enforce_admins\": false,
@@ -85,49 +156,50 @@ run_check "Block force-push and branch deletion" \
   \"allow_deletions\": false
 }
 BPEOF" \
-  "Branch protection may require Pro plan for private repos"
+    "Branch protection may require Pro plan for private repos"
 
-# --- Tag Protection ---
-echo ""
-echo "Tag Protection:"
-run_check "Protect v* release tags" \
-  "gh api repos/$REPO/tags/protection --method POST -f pattern='v*' --silent" \
-  "Tag protection may already exist or require Pro plan"
+  # --- Tag Protection ---
+  echo ""
+  echo "Tag Protection:"
+  run_check "Protect v* release tags" \
+    "gh api repos/$REPO/tags/protection --method POST -f pattern='v*' --silent" \
+    "Tag protection may already exist or require Pro plan"
 
-# --- Repository Settings ---
-echo ""
-echo "Repository Settings:"
-run_check "Enable delete-branch-on-merge" \
-  "gh repo edit $REPO --delete-branch-on-merge"
+  # --- Repository Settings ---
+  echo ""
+  echo "Repository Settings:"
+  run_check "Enable delete-branch-on-merge" \
+    "gh repo edit $REPO --delete-branch-on-merge"
 
-if [[ "$SKIP_WIKI" != "true" ]]; then
-  run_check "Disable Wiki" \
-    "gh repo edit $REPO --enable-wiki=false"
-fi
+  if [[ "$SKIP_WIKI" != "true" ]]; then
+    run_check "Disable Wiki" \
+      "gh repo edit $REPO --enable-wiki=false"
+  fi
 
-if [[ "$SKIP_PROJECTS" != "true" ]]; then
-  run_check "Disable Projects" \
-    "gh repo edit $REPO --enable-projects=false"
-fi
+  if [[ "$SKIP_PROJECTS" != "true" ]]; then
+    run_check "Disable Projects" \
+      "gh repo edit $REPO --enable-projects=false"
+  fi
 
-# --- Actions Permissions ---
-echo ""
-echo "Actions Permissions:"
-ACTIONS_INFO=$(gh api "repos/$REPO/actions/permissions" 2>/dev/null || echo '{}')
-ACTIONS_ENABLED=$(echo "$ACTIONS_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('enabled', 'unknown'))" 2>/dev/null || echo "unknown")
+  # --- Actions Permissions ---
+  echo ""
+  echo "Actions Permissions:"
+  ACTIONS_INFO=$(gh api "repos/$REPO/actions/permissions" 2>/dev/null || echo '{}')
+  ACTIONS_ENABLED=$(echo "$ACTIONS_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin).get('enabled', 'unknown'))" 2>/dev/null || echo "unknown")
 
-if [[ "$ACTIONS_ENABLED" == "True" || "$ACTIONS_ENABLED" == "true" ]]; then
-  echo -e "  ${GREEN}[INFO]${NC} Actions: enabled (SHA-pinning is the supply chain defense)"
-else
-  echo -e "  ${YELLOW}[INFO]${NC} Actions: $ACTIONS_ENABLED"
-fi
+  if [[ "$ACTIONS_ENABLED" == "True" || "$ACTIONS_ENABLED" == "true" ]]; then
+    echo -e "  ${GREEN}[INFO]${NC} Actions: enabled (SHA-pinning is the supply chain defense)"
+  else
+    echo -e "  ${YELLOW}[INFO]${NC} Actions: $ACTIONS_ENABLED"
+  fi
 
-# --- Default Actions Permissions ---
-run_check "Set default Actions permissions to read" \
-  "gh api -X PUT repos/$REPO/actions/permissions --input - <<'APEOF'
+  # --- Default Actions Permissions ---
+  run_check "Set default Actions permissions to read" \
+    "gh api -X PUT repos/$REPO/actions/permissions --input - <<'APEOF'
 {\"default_workflow_permissions\": \"read\"}
 APEOF" \
-  "May require org-level override"
+    "May require org-level override"
+fi
 
 # --- Local Protections Check (read-only) ---
 echo ""


### PR DESCRIPTION
Codex finding N5: `/project:security-audit` claimed audit but ran the mutating hardening script. Now `--audit` is a true read-only mode (GET requests only, proven by settings snapshots), and the command doc forbids unprompted mutation.

Tony