### PR TITLE
docs: five real ADRs (U14)

### DIFF
--- a/docs/decisions/001-sha-pinned-actions.md
+++ b/docs/decisions/001-sha-pinned-actions.md
@@ -1,0 +1,26 @@
+# ADR-001: SHA-Pin All GitHub Actions
+
+## Status
+
+Accepted (2026-03, platform-enforced 2026-08)
+
+## Context
+
+Third-party Actions run with access to the repository. Version tags (`@v4`) are mutable — a compromised action repo can move a tag onto malicious code and every consumer runs it on the next trigger. The 2025 npm supply-chain compromises (chalk/debug) made the moving-reference attack class concrete.
+
+## Decision
+
+Every `uses:` reference is pinned to a full 40-hex commit SHA with a trailing `# vX.Y.Z` comment. Enforcement is layered: an anchored self-test check (`@[0-9a-f]{40}$` on step-key lines — tag pins and `@main` both fail), the same check in Validate Template CI, Dependabot updating the pins, and since 2026-08 the platform-level `sha_pinning_required` Actions policy set by `secure-repo.sh`, so GitHub itself rejects unpinned actions.
+
+## Consequences
+
+### Positive
+
+- Immutable dependencies: a moved tag upstream cannot change what runs here
+- Dependabot PRs make updates auditable diffs (old SHA → new SHA)
+- Platform enforcement catches what convention misses
+
+### Negative
+
+- Pins go stale without Dependabot; the comment can lie about the SHA (the checker verifies the SHA format, not the comment's claim)
+- Slightly noisier workflow files

--- a/docs/decisions/002-rulesets-over-classic-protection.md
+++ b/docs/decisions/002-rulesets-over-classic-protection.md
@@ -1,0 +1,26 @@
+# ADR-002: Repository Rulesets over Classic Branch Protection
+
+## Status
+
+Accepted (2026-08)
+
+## Context
+
+The template originally used the classic branch-protection API and the tag-protection API. GitHub removed tag protection entirely (August 2024) — the script kept calling the dead endpoint and warned forever. Classic protection also lacks new capabilities (tag rulesets, push rules, PR-only bypass modes), and this repo's own misconfigured ruleset (`~ALL` branches with `always` bypass) blocked Dependabot rebases for months while the docs claimed protections that were not enforced.
+
+## Decision
+
+`secure-repo.sh` creates or updates rulesets by name: "Protect Main" (deletion + non_fast_forward + required status checks on the default branch, admin bypass only via PR) and "Protect Release Tags" (`v*`: no delete/move/update). Scope conditions to `~DEFAULT_BRANCH` — never `~ALL`, which breaks Dependabot's force-push rebases. Bypass mode is `pull_request`, never `always` (an always-bypass defeats the seatbelt for the solo admin it protects).
+
+## Consequences
+
+### Positive
+
+- Tags actually protected again; required checks reject direct pushes to main (verified by live probe)
+- Idempotent by name — re-running the script converges instead of duplicating
+- Docs, script, and enforced reality finally agree
+
+### Negative
+
+- Rulesets may be plan-gated on private repos (script degrades to WARN with remediation)
+- Required-check contexts are CI-job-name-specific; users must edit them when renaming jobs

--- a/docs/decisions/003-skills-directory-format.md
+++ b/docs/decisions/003-skills-directory-format.md
@@ -1,0 +1,26 @@
+# ADR-003: Skills Use the <name>/SKILL.md Directory Layout
+
+## Status
+
+Accepted (2026-08)
+
+## Context
+
+Six skills shipped April 2026 as flat `.claude/skills/<name>.md` files. Runtime verification (August 2026: a fixture repo with both layouts queried via `claude -p`) proved Claude Code silently ignores flat files and discovers only `<name>/SKILL.md` directories — every bundled skill had been dead weight for four months. The bundled skill-validator even taught the correct layout while the template shipped the wrong one.
+
+## Decision
+
+Every skill is a directory containing `SKILL.md` with `name` and `description` frontmatter (documented fields only — the undocumented `triggers:` list is ignored by Claude Code; trigger phrases belong in the description). A self-test design-check fails if any skill directory lacks SKILL.md or any flat skill file appears.
+
+## Consequences
+
+### Positive
+
+- Skills actually load (verified at runtime, both directions)
+- Directories can carry supporting files alongside SKILL.md
+- The layout mistake cannot silently recur
+
+### Negative
+
+- One-file skills carry directory overhead
+- Downstream repos created from pre-migration snapshots need manual migration

--- a/docs/decisions/004-two-agent-focus.md
+++ b/docs/decisions/004-two-agent-focus.md
@@ -1,0 +1,27 @@
+# ADR-004: Support Claude Code (Primary) and Codex — No Other Agents
+
+## Status
+
+Accepted (2026-08-06)
+
+## Context
+
+The template shipped config stubs for seven agents (Claude Code, Copilot, Cursor, Codex, Gemini, Windsurf, Aider) and marketed the count as its differentiator. In practice: five of the seven files were shallow mirrors that init-template asked users to keep in sync by hand, the sync chore was skipped (files drifted), and maintenance effort spread thin produced breadth without depth — while the genuinely deep support (Claude-native commands, skills, hooks) went undersold.
+
+## Decision
+
+Exactly two agent configs: `CLAUDE.md` for Claude Code (primary — carries the full `.claude/` toolkit: slash commands, auto-discovered skills, security hook templates, example sub-agent) and `AGENTS.md` for Codex via the open AGENTS.md standard. The other five configs and every reference to them were removed (maintainer decision, executed 2026-08-06). A self-test gate greps the tracked tree for removed-agent tokens (CHANGELOG history and CONTRIBUTORS bot names exempt) and fails CI if any reference resurfaces.
+
+## Consequences
+
+### Positive
+
+- One sync relationship (CLAUDE ↔ AGENTS) instead of a 7-file chore nobody performed
+- Depth as the honest differentiator; docs claim only what is maintained
+- AGENTS.md being an open standard means other adopting tools still benefit at zero cost
+- Regression-proof: the gate makes the descope permanent
+
+### Negative
+
+- Users of removed tools must author their own config (AGENTS.md is a good starting point)
+- Historical marketing claims ("7 agents") in old releases/posts no longer describe the template

--- a/docs/decisions/005-drift-severity-and-fail-closed.md
+++ b/docs/decisions/005-drift-severity-and-fail-closed.md
@@ -1,0 +1,26 @@
+# ADR-005: Drift Detection — Severity Tiers and Fail-Closed Verification
+
+## Status
+
+Accepted (2026-03, fail-closed hardening 2026-08)
+
+## Context
+
+Downstream repos created from the template go stale as the template improves. A reusable workflow compares file blob SHAs against the template. Two design questions: which files matter how much, and what to report when the comparison itself cannot run (rate limit, outage, renamed file). The original implementation silently treated "could not fetch" as "no drift" — reassuring reports during exactly the conditions where drift goes unnoticed.
+
+## Decision
+
+Three severity tiers: error (security-load-bearing: .gitattributes, SECURITY.md — missing fails the run), warn (security tooling: secret-scan workflow, CodeQL, dependency-review, secure-repo.sh, hook templates), info (expected to diverge: ci.yml, dependabot.yml, agent configs). Unverifiable files are counted and FAIL the run as "inconclusive, not clean" — a skipped check is never a pass. Catalog-managed content (e.g. installed skills) is versioned by its own manifest, not this workflow.
+
+## Consequences
+
+### Positive
+
+- Downstream repos learn about security-relevant divergence with proportionate urgency
+- Outages produce loud inconclusive runs instead of false green
+- Tier lists are explicit and reviewable
+
+### Negative
+
+- Fail-closed means transient GitHub API issues fail scheduled runs (rerun clears)
+- Tier lists need maintenance as files are added or renamed


### PR DESCRIPTION
Register U14. docs/decisions/ held only the template while the repo made (and un-made) major decisions; the five biggest are now recorded with honest context.

Tony