### PR TITLE
fix(release): preserve draft through asset uploads (v2.0.0 postmortem)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,17 @@ jobs:
             echo "Created: ${asset}.sigstore.json"
           done
 
+      # draft: true is LOAD-BEARING on every softprops call below. The action
+      # UPDATES the existing release; omitting draft resets it to published —
+      # which is exactly what happened on v2.0.0: the signature upload
+      # published early, immutable-releases locked the release instantly, and
+      # the SBOM could never be attached ("Cannot upload assets to an
+      # immutable release"). Assets must be complete BEFORE the publish gate.
       - name: Upload signatures to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: /tmp/release-assets/*.sigstore.json
+          draft: true
 
       # ──────────────────────────────────────────────────────────
       # SBOM (Software Bill of Materials)
@@ -110,16 +117,21 @@ jobs:
       # and helps downstream consumers audit dependencies.
       # ──────────────────────────────────────────────────────────
 
+      # upload-release-assets is disabled: the action's built-in attach
+      # runs against the release AFTER resolving it by tag, outside our
+      # draft-preserving flow. We attach via the draft-aware step below.
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: cyclonedx-json
           output-file: /tmp/release-assets/sbom.cyclonedx.json
+          upload-release-assets: false
 
       - name: Upload SBOM to release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: /tmp/release-assets/sbom.cyclonedx.json
+          draft: true
 
       # Only reached when signing + SBOM succeeded — the publish gate.
       - name: Publish release


### PR DESCRIPTION
Live-fire finding from the v2.0.0 release: our own immutability hardening locked the release the moment a draft-unaware softprops call published it early, orphaning the SBOM step. Draft is now preserved through every asset upload; publish remains the final gate.

Tony