### PR TITLE
docs: scope elevated agent permissions to authorized tasks

### DIFF
--- a/docs/AI-SECURITY.md
+++ b/docs/AI-SECURITY.md
@@ -91,7 +91,7 @@ These files control AI agent behavior and are protected by CODEOWNERS:
 
 4. **Install scanning hooks** -- Copy the templates from `.claude/hooks/` and register them in your agent configuration.
 
-5. **Limit agent permissions** -- Agents should have the minimum permissions needed. Never give an agent admin or direct push access.
+5. **Scope agent permissions to the task** -- Prefer the minimum permissions needed. Repository-administration operations such as first-time hardening may require elevated rights; use those rights only when explicitly authorized for that operation, and do not grant a standing bypass around protected-branch or review controls.
 
 ### For Contributors
 


### PR DESCRIPTION
## Change

Replace the blanket instruction that agents must never have repository-admin access with task-scoped least-privilege guidance.

Repository hardening and other explicitly authorized administration operations may require elevated permissions. The revised language permits that elevation for the authorized operation while retaining protected-branch/review boundaries and discouraging standing bypass privileges.

## Why

`repo-template` is now intentionally agent-native. Its security guidance should support controlled agentic repository administration rather than contradict the Phase 0/hardening workflow.