### PR TITLE
feat: add downstream template reconciliation

### DIFF
--- a/.claude/commands/upgrade-template.md
+++ b/.claude/commands/upgrade-template.md
@@ -1,0 +1,5 @@
+# Upgrade Template
+
+For an existing repository derived from `vbonk/repo-template`, use the reconciliation model in `docs/TEMPLATE-UPGRADE.md` and the provenance marker in `.repo-template.yaml`.
+
+Do not treat a mature project as a fresh Phase 0 instance. Preserve project-specific work and reconcile later template capabilities against the project's historical baseline.

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,28 +1,21 @@
-# Template Drift Detection — Reusable Workflow
-# Compares key files in a downstream repo against the template source.
-# Reports drift so maintainers know when to update.
+# Template Compatibility — Reusable Workflow
+# Historical path retained for compatibility: check-template-drift.yml.
 #
-# Usage in downstream repos:
-#   name: Template Drift Check
-#   on:
-#     schedule:
-#       - cron: '0 9 * * 1'  # Weekly Monday 9am
-#     workflow_dispatch:
-#   jobs:
-#     check:
-#       uses: vbonk/repo-template/.github/workflows/check-template-drift.yml@main
+# Downstream repositories are expected to diverge from repo-template after
+# Phase 0. This workflow therefore compares template provenance baselines,
+# not project file hashes.
 
-name: Check Template Drift
+name: Check Template Compatibility
 
 on:
   workflow_call:
     inputs:
       template_repo:
-        description: 'Template repository to compare against'
+        description: 'Template repository that defines the current baseline'
         default: 'vbonk/repo-template'
         type: string
       severity:
-        description: 'Minimum severity to report (info, warn, error)'
+        description: 'How to treat an outdated or legacy baseline (info, warn, error)'
         default: 'warn'
         type: string
 
@@ -30,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  drift-check:
+  compatibility:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -38,92 +31,59 @@ jobs:
       - name: Checkout downstream repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Check for template drift
+      - name: Compare template baselines
         env:
           TEMPLATE_REPO: ${{ inputs.template_repo }}
           GH_TOKEN: ${{ github.token }}
           SEVERITY: ${{ inputs.severity }}
         run: |
-          echo "=== Template Drift Check ==="
+          set -u
+          echo "=== Template Compatibility Check ==="
           echo "Template: $TEMPLATE_REPO"
           echo "Downstream: $GITHUB_REPOSITORY"
-          echo ""
 
-          DRIFT=0
-          WARNINGS=0
-          FETCH_FAILURES=0
+          template_marker=$(gh api \
+            -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$TEMPLATE_REPO/contents/.repo-template.yaml" 2>/dev/null || true)
 
-          check_file() {
-            local file="$1"
-            local level="$2"
-
-            if [ ! -f "$file" ]; then
-              if [ "$level" = "error" ] || [ "$level" = "warn" ]; then
-                echo "::${level}::MISSING: $file (exists in template but not in this repo)"
-                DRIFT=$((DRIFT + 1))
-              fi
-              return
-            fi
-
-            TEMPLATE_SHA=$(gh api "repos/$TEMPLATE_REPO/contents/$file" --jq '.sha' 2>/dev/null || echo "")
-            if [ -z "$TEMPLATE_SHA" ]; then
-              # FAIL CLOSED: an unreadable template blob (auth failure, rate
-              # limit, renamed file, outage) is NOT "no drift" — silently
-              # returning here produced reassuring zero-drift reports during
-              # exactly the conditions where drift goes unnoticed.
-              echo "::error::Cannot fetch template SHA for $file — drift status UNVERIFIED"
-              FETCH_FAILURES=$((FETCH_FAILURES + 1))
-              return
-            fi
-
-            LOCAL_SHA=$(git hash-object "$file" 2>/dev/null || echo "")
-
-            if [ "$TEMPLATE_SHA" != "$LOCAL_SHA" ]; then
-              echo "  DRIFT: $file (modified from template)"
-              WARNINGS=$((WARNINGS + 1))
-            else
-              echo "  OK: $file (matches template)"
-            fi
-          }
-
-          echo "--- Security Files (error if missing) ---"
-          check_file ".gitattributes" "error"
-          check_file "SECURITY.md" "error"
-          check_file ".github/workflows/secret-scan-pr.yml" "warn"
-
-          echo ""
-          echo "--- CI/CD Files (warn if different) ---"
-          check_file ".github/workflows/ci.yml" "info"
-          check_file ".github/dependabot.yml" "info"
-          check_file ".github/workflows/codeql.yml" "warn"
-          check_file ".github/workflows/dependency-review.yml" "warn"
-
-          echo ""
-          echo "--- AI Config Files (info — expected to diverge) ---"
-          check_file "CLAUDE.md" "info"
-          check_file "AGENTS.md" "info"
-
-          echo ""
-          echo "--- Scripts (warn if missing) ---"
-          check_file "scripts/secure-repo.sh" "warn"
-          check_file "templates/hooks/pre-commit-secrets.sh.template" "warn"
-          check_file "templates/hooks/setup-hooks.sh" "warn"
-
-          echo ""
-          echo "=== Results: $DRIFT missing | $WARNINGS drifted | $FETCH_FAILURES unverifiable ==="
-
-          if [ "$DRIFT" -gt 0 ]; then
-            echo ""
-            echo "Run /project:init-template or manually copy missing files from the template."
-            echo "Template: https://github.com/$TEMPLATE_REPO"
-          fi
-
-          # Fail closed: files we could not verify are not "no drift".
-          if [ "$FETCH_FAILURES" -gt 0 ]; then
-            echo "::error::$FETCH_FAILURES file(s) could not be verified against the template — treat this run as inconclusive, not clean"
+          if [ -z "$template_marker" ]; then
+            echo "::error::Current template provenance marker could not be read; compatibility is unverified."
             exit 1
           fi
 
-          if [ "$DRIFT" -gt 0 ] && [ "$SEVERITY" = "error" ]; then
+          current_baseline=$(printf '%s\n' "$template_marker" | awk -F': *' '$1 == "baseline_id" {print $2; exit}')
+          if [ -z "$current_baseline" ]; then
+            echo "::error::Current template marker has no baseline_id; compatibility is unverified."
             exit 1
           fi
+
+          if [ ! -f .repo-template.yaml ]; then
+            message="Legacy pre-marker repository. Reconcile with the current repo-template baseline: $current_baseline"
+            case "$SEVERITY" in
+              error) echo "::error::$message"; exit 1 ;;
+              warn)  echo "::warning::$message" ;;
+              *)     echo "::notice::$message" ;;
+            esac
+            exit 0
+          fi
+
+          local_baseline=$(awk -F': *' '$1 == "baseline_id" {print $2; exit}' .repo-template.yaml)
+          if [ -z "$local_baseline" ]; then
+            echo "::error::.repo-template.yaml has no baseline_id; compatibility is unverified."
+            exit 1
+          fi
+
+          echo "Project baseline:  $local_baseline"
+          echo "Current baseline:  $current_baseline"
+
+          if [ "$local_baseline" = "$current_baseline" ]; then
+            echo "Template baseline is current. Project-specific file divergence is expected and is not treated as drift."
+            exit 0
+          fi
+
+          message="Template baseline is outdated ($local_baseline -> $current_baseline). Use semantic reconciliation; do not synchronize project files blindly."
+          case "$SEVERITY" in
+            error) echo "::error::$message"; exit 1 ;;
+            warn)  echo "::warning::$message" ;;
+            *)     echo "::notice::$message" ;;
+          esac

--- a/.github/workflows/validate-template.yml
+++ b/.github/workflows/validate-template.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Validate YAML files
         run: |
           echo "--- Validating YAML files ---"
-          # Probe the validator first: missing pyyaml must fail loudly as
-          # "validator unavailable", never masquerade as N invalid files.
           if ! python3 -c "import yaml" 2>/dev/null; then
             echo "::error::pyyaml not available — YAML validation cannot run (this is a hard failure, not a pass)"
             exit 1
@@ -48,9 +46,6 @@ jobs:
       - name: Validate JSON files
         run: |
           echo "--- Validating JSON files ---"
-          # Uses scripts/validate-jsonc.py which strips // and /* */ comments before
-          # parsing, so devcontainer.json and .vscode/*.json template files with
-          # instructional comments are treated as valid JSONC.
           FILES=$(find . -name '*.json' | grep -v node_modules | sort | tr '\n' ' ')
           # shellcheck disable=SC2086
           python3 scripts/validate-jsonc.py $FILES || {
@@ -81,9 +76,6 @@ jobs:
       - name: Verify all actions are SHA-pinned
         run: |
           echo "--- Checking SHA-pinned actions ---"
-          # Anchored check: EVERY active step-key `uses:` ref must end in a
-          # 40-hex SHA. The old grep-for-@vN approach missed `@main` entirely
-          # and dropped any line containing '#' — so `@v4 # v4` escaped too.
           UNPINNED=0
           while IFS= read -r line; do
             case "$(echo "$line" | sed 's/^[[:space:]]*//')" in \#*) continue ;; esac
@@ -146,14 +138,23 @@ jobs:
           fi
           echo "No secrets patterns found."
 
-      - name: Verify agent-native Phase 0 contract
+      - name: Verify agent-native Phase 0 and reconciliation contracts
         run: |
-          echo "--- Checking first-agent bootstrap invariants ---"
+          echo "--- Checking first-agent and upgrade invariants ---"
           test -f docs/PHASE-0.md || { echo "::error::docs/PHASE-0.md missing"; exit 1; }
           grep -q 'KEEP / ADAPT / REMOVE / DEFER' docs/PHASE-0.md || { echo "::error::Phase 0 classification contract missing"; exit 1; }
           grep -q 'Derived-repository mode' CLAUDE.md || { echo "::error::CLAUDE.md missing derived-repository detection"; exit 1; }
           grep -q 'Derived-repository mode' AGENTS.md || { echo "::error::AGENTS.md missing derived-repository detection"; exit 1; }
           grep -q 'The Golden Path' README.md || { echo "::error::README missing agent-first golden path"; exit 1; }
+
+          test -f .repo-template.yaml || { echo "::error::.repo-template.yaml missing"; exit 1; }
+          grep -q '^baseline_id: agent-native-phase0-v1$' .repo-template.yaml || { echo "::error::unexpected template baseline_id"; exit 1; }
+          grep -q 'strategy: semantic-reconciliation' .repo-template.yaml || { echo "::error::semantic reconciliation policy missing"; exit 1; }
+          test -f docs/TEMPLATE-UPGRADE.md || { echo "::error::template upgrade guidance missing"; exit 1; }
+          test -f .claude/commands/upgrade-template.md || { echo "::error::Claude template-upgrade entrypoint missing"; exit 1; }
+          grep -q 'Existing derived project' CLAUDE.md || { echo "::error::CLAUDE.md missing mature-project upgrade distinction"; exit 1; }
+          grep -q 'Existing derived project' AGENTS.md || { echo "::error::AGENTS.md missing mature-project upgrade distinction"; exit 1; }
+
           if grep -qE 'Client.*API Server|npm run dev|DATABASE_URL|NODE_ENV|Production.*main branch' CLAUDE.md AGENTS.md .env.example; then
             echo "::error::Speculative application defaults returned to root agent/config surfaces"
             exit 1
@@ -178,4 +179,12 @@ jobs:
             echo "::error::E2E suite still validates superseded onboarding journeys"
             exit 1
           fi
-          echo "Agent-native Phase 0 contract is intact."
+          grep -q 'Template baseline is current' .github/workflows/check-template-drift.yml || {
+            echo "::error::compatibility workflow is not baseline-aware"
+            exit 1
+          }
+          if grep -q 'git hash-object' .github/workflows/check-template-drift.yml; then
+            echo "::error::compatibility workflow returned to exact downstream file-hash matching"
+            exit 1
+          fi
+          echo "Agent-native Phase 0 and template reconciliation contracts are intact."

--- a/.repo-template.yaml
+++ b/.repo-template.yaml
@@ -1,0 +1,6 @@
+schema_version: 1
+source_repository: vbonk/repo-template
+baseline_id: agent-native-phase0-v1
+upgrade:
+  strategy: semantic-reconciliation
+  canonical_spec: https://github.com/vbonk/repo-template/blob/main/docs/TEMPLATE-UPGRADE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,19 +29,25 @@ For derived repositories:
 5. Remove assumptions before adding implementation.
 6. Do not choose a stack, architecture, deployment target, dependency ecosystem, or license without project evidence.
 7. Preserve useful repository hygiene and security controls.
-8. If the real project is already available, normalize and integrate it in the same workflow rather than forcing an intermediate substrate commit.
-9. Ask only when a material decision is genuinely unknowable or unsafe to infer.
-10. Replace these generic instructions with project-specific instructions when Phase 0 completes.
+8. Preserve `.repo-template.yaml` as the template-provenance marker; its source-template reference is intentional.
+9. If the real project is already available, normalize and integrate it in the same workflow rather than forcing an intermediate substrate commit.
+10. Ask only when a material decision is genuinely unknowable or unsafe to infer.
+11. Replace these generic instructions with project-specific instructions when Phase 0 completes.
+
+### Existing derived project
+
+If the repository already contains project-specific instructions and substantial project work, do not rerun Phase 0 merely because the source template has evolved. When a template update is requested, use `.repo-template.yaml` and [docs/TEMPLATE-UPGRADE.md](docs/TEMPLATE-UPGRADE.md) (or the canonical source document referenced by the marker) to reconcile the historical template baseline, current project, and current template.
 
 ## Source Template Project
 
 **Name:** repo-template  
-**Purpose:** Secure, agent-native GitHub template optimized for Claude Code and Codex, with a canonical first-agent normalization path for derived repositories.
+**Purpose:** Secure, agent-native GitHub template optimized for Claude Code and Codex, with first-agent normalization and repeatable downstream reconciliation.
 
 ### Architecture
 
 - **Agent entry:** `CLAUDE.md`, `AGENTS.md`, `.claude/`
 - **Bootstrap/intake:** `docs/PHASE-0.md`
+- **Template provenance/upgrades:** `.repo-template.yaml`, `docs/TEMPLATE-UPGRADE.md`
 - **Security/governance:** `.github/`, repository policies, hardening scripts, hooks
 - **Verification:** template tests, compliance audit, GitHub Actions
 
@@ -91,8 +97,9 @@ A template change is not complete until:
 - no speculative project assumptions were introduced into downstream entry surfaces;
 - security controls were preserved or intentionally replaced;
 - references and links remain valid;
-- first-agent usability in derived repositories did not regress.
+- first-agent usability in derived repositories did not regress;
+- downstream compatibility/provenance behavior remains coherent.
 
 ---
 
-> See also: [CLAUDE.md](CLAUDE.md) | [Phase 0](docs/PHASE-0.md) | [AI Security](docs/AI-SECURITY.md)
+> See also: [CLAUDE.md](CLAUDE.md) | [Phase 0](docs/PHASE-0.md) | [Template Upgrade](docs/TEMPLATE-UPGRADE.md) | [AI Security](docs/AI-SECURITY.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,21 +29,27 @@ For derived repositories:
 5. Remove assumptions before adding implementation.
 6. Do not choose a stack, architecture, deployment target, dependency ecosystem, or license without project evidence.
 7. Preserve useful repository hygiene and security controls.
-8. If the real project is already available, normalize and integrate it in the same workflow; do not force an unnecessary intermediate substrate commit.
-9. Ask only when a material decision is genuinely unknowable or unsafe to infer.
-10. Replace these generic instructions with project-specific instructions when Phase 0 completes.
+8. Preserve `.repo-template.yaml` as the small template-provenance marker; it is intentionally allowed to retain a reference to `vbonk/repo-template`.
+9. If the real project is already available, normalize and integrate it in the same workflow; do not force an unnecessary intermediate substrate commit.
+10. Ask only when a material decision is genuinely unknowable or unsafe to infer.
+11. Replace these generic instructions with project-specific instructions when Phase 0 completes.
 
 Explicit fallback: `/project:bootstrap`.
+
+### Existing derived project
+
+If the repository already contains project-specific instructions and substantial project work, do **not** rerun Phase 0 simply because `repo-template` has changed. When the user requests a template update, use `.repo-template.yaml` and [docs/TEMPLATE-UPGRADE.md](docs/TEMPLATE-UPGRADE.md) (or the canonical source document referenced by the marker) for semantic reconciliation.
 
 ## Source Template Project
 
 **Name:** repo-template  
-**Purpose:** Secure, agent-native GitHub template optimized for Claude Code and Codex, with a canonical first-agent normalization path for derived repositories.
+**Purpose:** Secure, agent-native GitHub template optimized for Claude Code and Codex, with first-agent normalization and repeatable downstream reconciliation.
 
 ### Architecture
 
 - **Agent entry:** `CLAUDE.md`, `AGENTS.md`, `.claude/`
 - **Bootstrap/intake:** `docs/PHASE-0.md` and `/project:bootstrap`
+- **Template provenance/upgrades:** `.repo-template.yaml`, `docs/TEMPLATE-UPGRADE.md`, `/project:upgrade-template`
 - **Security/governance:** `.github/`, repository policies, hardening scripts, hooks
 - **Verification:** template tests, compliance audit, GitHub Actions
 
@@ -80,7 +86,8 @@ See [docs/AI-SECURITY.md](docs/AI-SECURITY.md).
 
 ## Claude Toolkit
 
-- `/project:bootstrap` — normalize a derived repository and ingest available project context
+- `/project:bootstrap` — normalize a fresh derived repository and ingest available project context
+- `/project:upgrade-template` — reconcile an existing derived project with a newer template baseline
 - `/project:init-template` — deprecated compatibility alias for bootstrap
 - `/project:security-audit` — read-only security scorecard
 - `/project:review` — review assistance
@@ -98,8 +105,9 @@ A template change is not complete until:
 - no speculative project assumptions were introduced into downstream entry surfaces;
 - security controls were preserved or intentionally replaced;
 - references and links remain valid;
-- first-agent usability in derived repositories did not regress.
+- first-agent usability in derived repositories did not regress;
+- downstream compatibility/provenance behavior remains coherent.
 
 ---
 
-> See also: [AGENTS.md](AGENTS.md) | [Phase 0](docs/PHASE-0.md) | [AI Security](docs/AI-SECURITY.md)
+> See also: [AGENTS.md](AGENTS.md) | [Phase 0](docs/PHASE-0.md) | [Template Upgrade](docs/TEMPLATE-UPGRADE.md) | [AI Security](docs/AI-SECURITY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-> Navigation hub for `repo-template` documentation. Template-derived repositories should begin with Phase 0 so inherited reference material is interpreted in the correct context.
+> Navigation hub for `repo-template` documentation. Fresh template-derived repositories begin with Phase 0; existing projects use Template Upgrade when reconciling a newer baseline.
 
 **Last Updated:** 2026-08-13
 
@@ -8,7 +8,8 @@
 
 | Document | Purpose |
 |---|---|
-| [PHASE-0.md](PHASE-0.md) | Canonical first-agent normalization and project-intake SOP for template-derived repositories |
+| [PHASE-0.md](PHASE-0.md) | Canonical first-agent normalization and project-intake SOP for fresh template-derived repositories |
+| [TEMPLATE-UPGRADE.md](TEMPLATE-UPGRADE.md) | Semantic reconciliation for existing repositories derived from older template baselines |
 | [GETTING-STARTED.md](GETTING-STARTED.md) | Short agent-first usage guide |
 | [AI-SECURITY.md](AI-SECURITY.md) | Prompt-injection threat model and agent security boundaries |
 | [DOCUMENTATION-GUIDE.md](DOCUMENTATION-GUIDE.md) | Documentation quality standard and pattern library |
@@ -27,7 +28,7 @@
 | Document | Purpose |
 |---|---|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Architecture of the `repo-template` source project |
-| [decisions/](decisions/) | Architecture Decision Records (ADRs), including agent-native bootstrap decisions |
+| [decisions/](decisions/) | Architecture Decision Records, including first-agent and downstream reconciliation decisions |
 
 ## Root-Level Project Docs
 
@@ -36,10 +37,11 @@
 | [README.md](../README.md) | Source template overview and golden path |
 | [CLAUDE.md](../CLAUDE.md) | Claude Code source/derived repository entry rules |
 | [AGENTS.md](../AGENTS.md) | Codex source/derived repository entry rules |
+| [.repo-template.yaml](../.repo-template.yaml) | Stable template provenance/reconciliation baseline |
 | [SECURITY.md](../SECURITY.md) | Security policy and vulnerability reporting |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Contribution guidelines for the source template |
 | [GOVERNANCE.md](../GOVERNANCE.md) | Source-template governance |
 | [CHANGELOG.md](../CHANGELOG.md) | Version history |
 
 > [!IMPORTANT]
-> Source-template documentation is inherited reference material in a derived repository. Phase 0 determines which parts remain relevant before the downstream project is materialized.
+> Source-template documentation is inherited reference material in a fresh derived repository. Phase 0 determines which parts remain relevant, while `.repo-template.yaml` remains as the small provenance anchor for future reconciliation.

--- a/docs/TEMPLATE-UPGRADE.md
+++ b/docs/TEMPLATE-UPGRADE.md
@@ -1,0 +1,18 @@
+# Template Upgrade
+
+This document defines how an existing repository descended from `vbonk/repo-template` can be compared with a newer template baseline while keeping project-specific work authoritative.
+
+Phase 0 applies to fresh template instances. Template Upgrade applies after project-specific history exists.
+
+Repository classes:
+- PRISTINE: no meaningful project work; the inherited substrate can be refreshed before Phase 0.
+- LIGHTLY CUSTOMIZED: reconcile inherited material with project edits.
+- PROJECT MATURE: treat repo-template as ancestry and evaluate newer capabilities selectively.
+
+Current instances carry `.repo-template.yaml` with a stable `baseline_id`. Older repositories without the marker are supported by identifying the closest historical template baseline from repository history and inherited files.
+
+Use a three-way model: A = historical template baseline, B = current project, C = current template. Compare A→B with A→C so template evolution can be considered without erasing project evolution.
+
+After a successful reconciliation, the provenance marker identifies the newest baseline reconciled into the project. The marker records ancestry only; it is not lifecycle state.
+
+Current baseline: `agent-native-phase0-v1` (2026-08-13).

--- a/docs/decisions/007-template-upgrade-reconciliation.md
+++ b/docs/decisions/007-template-upgrade-reconciliation.md
@@ -1,0 +1,35 @@
+# ADR 007 — Semantic Reconciliation for Downstream Template Upgrades
+
+**Status:** Accepted  
+**Date:** 2026-08-13
+
+## Context
+
+Repositories created from a GitHub template do not remain ordinary upstream branches of the source template. After Phase 0, downstream repositories intentionally diverge: project-specific README files, agent instructions, workflows, architecture, and source replace inherited scaffolding.
+
+A simple file-sync or "make it match current repo-template" approach would therefore destroy legitimate project evolution.
+
+## Decision
+
+Downstream upgrades use semantic reconciliation rather than exact synchronization.
+
+A small `.repo-template.yaml` marker records the source template and a stable `baseline_id`. Upgrade reasoning compares three conceptual states: the historical template baseline, the current project, and the current template baseline.
+
+Fresh/pristine legacy instances may adopt the complete newer substrate after pristine state is verified. Mature repositories evaluate later template capabilities selectively and keep project-owned material authoritative.
+
+The baseline ID is intentionally not a Git commit SHA. A file cannot reliably encode the SHA of the commit that contains itself, and downstream compatibility changes less frequently than individual template commits.
+
+## Consequences
+
+- Future agents can identify the last reconciled template baseline without reconstructing all history.
+- Intentional project divergence is not treated as an error.
+- Older repositories without the marker remain supported through conservative historical-baseline inference.
+- Template releases should bump the baseline ID when downstream compatibility meaningfully changes.
+- Phase 0 remains simple and separate from mature-project maintenance.
+
+## Alternatives Rejected
+
+- **Always recreate repositories from the newest template:** loses repository continuity and is unnecessary.
+- **Exact upstream file sync:** conflicts with intentional project customization.
+- **Full lifecycle state machine:** adds state unrelated to the narrower provenance problem.
+- **Embed current Git SHA in the marker:** self-referential and brittle.

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -2,8 +2,8 @@
 # test-e2e.sh — End-to-end template validation (Layer 5)
 # Usage: bash scripts/test-e2e.sh [--keep] [--skip-cleanup]
 #
-# Creates one real repository from repo-template, verifies the first-agent
-# contract and security baseline, then deletes the repository on success.
+# Creates one real repository from repo-template, verifies the first-agent,
+# provenance, reconciliation, and security contracts, then deletes it on success.
 # Requires: gh CLI authenticated with repo create/delete permissions.
 set -uo pipefail
 
@@ -42,7 +42,7 @@ WORK_DIR=$(mktemp -d)
 REPOS_TO_DELETE=()
 DIRS_TO_DELETE=("$WORK_DIR")
 
-# shellcheck disable=SC2317,SC2329  # invoked indirectly via EXIT trap
+# shellcheck disable=SC2317,SC2329
 cleanup() {
   if $KEEP; then
     echo ""
@@ -99,17 +99,18 @@ if [[ "${TEST_REPO_SKIP:-}" != "true" ]]; then
   cd "$WORK_DIR/$REPO_NAME" || { fail "Failed to enter cloned repository"; exit 1; }
 
   essential_ok=true
-  for f in README.md CLAUDE.md AGENTS.md docs/PHASE-0.md \
-           .claude/commands/bootstrap.md .gitattributes .gitignore \
-           scripts/secure-repo.sh templates/hooks/setup-hooks.sh \
-           templates/hooks/pre-commit-secrets.sh.template; do
+  for f in README.md CLAUDE.md AGENTS.md .repo-template.yaml \
+           docs/PHASE-0.md docs/TEMPLATE-UPGRADE.md \
+           .claude/commands/bootstrap.md .claude/commands/upgrade-template.md \
+           .gitattributes .gitignore scripts/secure-repo.sh \
+           templates/hooks/setup-hooks.sh templates/hooks/pre-commit-secrets.sh.template; do
     if [[ ! -f "$f" ]]; then
       fail "Missing after template creation: $f"
       essential_ok=false
     fi
   done
   if $essential_ok; then
-    pass "First-agent and security files transfer with the template"
+    pass "First-agent, provenance, reconciliation, and security files transfer"
   fi
 
   if grep -q 'Derived-repository mode' CLAUDE.md && \
@@ -124,6 +125,20 @@ if [[ "${TEST_REPO_SKIP:-}" != "true" ]]; then
     pass "Phase 0 carries classification and session-intake contracts"
   else
     fail "Phase 0 contract is incomplete"
+  fi
+
+  if grep -q '^baseline_id: agent-native-phase0-v1$' .repo-template.yaml && \
+     grep -q 'strategy: semantic-reconciliation' .repo-template.yaml; then
+    pass "Template provenance marker carries the current reconciliation baseline"
+  else
+    fail "Template provenance marker is missing or incorrect"
+  fi
+
+  if grep -q 'three-way model' docs/TEMPLATE-UPGRADE.md && \
+     grep -q 'docs/TEMPLATE-UPGRADE.md' .claude/commands/upgrade-template.md; then
+    pass "Template upgrade guidance and Claude entrypoint transfer"
+  else
+    fail "Template upgrade reconciliation contract is incomplete"
   fi
 
   if grep -q 'docs/PHASE-0.md' .claude/commands/bootstrap.md && \
@@ -236,25 +251,29 @@ if [[ "${TEST_REPO_SKIP:-}" != "true" ]]; then
 fi
 
 # ============================================================
-# TEST 5.4: Drift Detection Core Logic
+# TEST 5.4: Template Baseline Compatibility
 # ============================================================
-header "5.4: Drift Detection"
+header "5.4: Template Baseline Compatibility"
 
 if [[ "${TEST_REPO_SKIP:-}" != "true" ]]; then
   cd "$WORK_DIR/$REPO_NAME" || exit 1
 
-  if [[ -f SECURITY.md ]]; then
-    echo "# Modified" >> SECURITY.md
-    TEMPLATE_SHA=$(gh api "repos/$TEMPLATE_REPO/contents/SECURITY.md" --jq '.sha' 2>/dev/null || echo "")
-    LOCAL_SHA=$(git hash-object SECURITY.md 2>/dev/null || echo "")
+  local_baseline=$(awk -F': *' '$1 == "baseline_id" {print $2; exit}' .repo-template.yaml)
+  template_baseline=$(gh api -H 'Accept: application/vnd.github.raw+json' \
+    "repos/$TEMPLATE_REPO/contents/.repo-template.yaml" 2>/dev/null | \
+    awk -F': *' '$1 == "baseline_id" {print $2; exit}')
 
-    if [[ -n "$TEMPLATE_SHA" && -n "$LOCAL_SHA" && "$TEMPLATE_SHA" != "$LOCAL_SHA" ]]; then
-      pass "Drift core logic identifies a modified protected file"
-    else
-      fail "Drift core logic did not identify modified SECURITY.md"
-    fi
+  if [[ -n "$local_baseline" && "$local_baseline" = "$template_baseline" ]]; then
+    pass "Fresh derived repository records the current template baseline"
   else
-    warn "SECURITY.md not found in test repository"
+    fail "Fresh derived repository baseline does not match the source template"
+  fi
+
+  if grep -q 'Template baseline is current' .github/workflows/check-template-drift.yml && \
+     ! grep -q 'git hash-object' .github/workflows/check-template-drift.yml; then
+    pass "Compatibility workflow checks baseline provenance, not exact project file hashes"
+  else
+    fail "Compatibility workflow still assumes downstream files should match the template"
   fi
 
   cd "$REPO_ROOT" || exit 1


### PR DESCRIPTION
## Summary

- Add `.repo-template.yaml` with stable baseline `agent-native-phase0-v1`.
- Add `docs/TEMPLATE-UPGRADE.md`, `/project:upgrade-template`, and ADR 007.
- Distinguish fresh Phase 0 from later updates to established projects in Claude/Codex instructions.
- Change the historical drift workflow to compare baseline provenance rather than downstream file hashes.
- Extend validation and E2E coverage so new repositories inherit the provenance and reconciliation contract.

## Rationale

Repositories intentionally diverge after Phase 0. Older pristine instances should be refreshable without recreation, while established projects should reconcile later template improvements without resetting project-owned work.

Opened as draft for the normal repository checks.